### PR TITLE
feat: Add Together.AI provider and models to Streamlit sidebar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ OPENROUTER_DEFAULT_MODEL="google/gemma-3-27b-it:free"
 # Add these for Groq
 GROQ_API_KEY="YOUR_GROQ_API_KEY"
 GROQ_DEFAULT_MODEL="llama3-8b-8192"
+
+# Add these for Together.AI
+TOGETHERAI_API_KEY=""
+TOGETHERAI_DEFAULT_MODEL="meta-llama/Llama-3.3-70B-Instruct-Turbo-Free"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project is a **AI Travel Agent** demonstrating an AI-powered travel automat
   - Submit new travel enquiries with details like destination, duration, number of travelers, trip type, and client information.
 - **AI Itinerary Suggestions:**
   - Generate AI-powered suggestions for places and attractions based on enquiry details.
-  - Selectable AI providers (Google Gemini, OpenRouter, Groq).
+  - Selectable AI providers (Google Gemini, OpenRouter, Groq, Together.AI).
 - **Vendor Reply Integration:**
   - Input and store vendor replies, including pricing, inclusions, and exclusions.
 - **AI Quotation Generation:**
@@ -27,8 +27,8 @@ This project is a **AI Travel Agent** demonstrating an AI-powered travel automat
 - **Data Persistence:**
   - All enquiries, client details, itineraries, vendor replies, and quotation metadata are stored in a Supabase PostgreSQL database.
 - **Configurable AI:**
-  - Choose between different AI providers (Gemini, OpenRouter, Groq) for content generation tasks.
-  - Specify default models for OpenRouter and Groq via environment variables.
+  - Choose between different AI providers (Gemini, OpenRouter, Groq, Together.AI) for content generation tasks.
+  - Specify default models for OpenRouter, Groq, and Together.AI via environment variables.
 
 ---
 
@@ -39,7 +39,7 @@ This project is a **AI Travel Agent** demonstrating an AI-powered travel automat
 - **AI/LLM Integration:**
   - Langchain
   - LangGraph (for orchestrating quotation generation steps)
-  - LLM Providers: Google Gemini, OpenRouter, Groq
+  - LLM Providers: Google Gemini, OpenRouter, Groq, Together.AI
 - **Document Generation:**
   - FPDF2 (`fpdf`) for PDF creation
   - `pdf2docx` for PDF to DOCX conversion
@@ -119,6 +119,7 @@ This project is a **AI Travel Agent** demonstrating an AI-powered travel automat
   - Google API Key (if using Gemini)
   - OpenRouter API Key (if using OpenRouter)
   - Groq API Key (if using Groq)
+  - Together.AI API Key (if using Together.AI)
 
 ### Steps
 
@@ -155,6 +156,8 @@ This project is a **AI Travel Agent** demonstrating an AI-powered travel automat
      OPENROUTER_APP_TITLE="AI Travel Quotation" # Optional, set your app's title
      GROQ_API_KEY="YOUR_GROQ_API_KEY"
      GROQ_DEFAULT_MODEL="llama3-8b-8192" # Optional, specify default Groq model
+     TOGETHERAI_API_KEY="YOUR_TOGETHERAI_API_KEY"
+     TOGETHERAI_DEFAULT_MODEL="meta-llama/Llama-3.3-70B-Instruct-Turbo-Free" # Optional, supported: "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free", "deepseek-ai/DeepSeek-R1-Distill-Llama-70B-free"
      ```
 5. **Supabase Setup:**
    - Go to your Supabase project dashboard.
@@ -226,8 +229,8 @@ The application is organized into three main tabs:
 
 ### Global AI Configuration (Sidebar)
 
-- Use the sidebar to select the AI Provider (Gemini or OpenRouter) that will be used for all LLM tasks (itinerary suggestions, quotation structuring).
-- The currently active provider and model (for OpenRouter) are displayed.
+- Use the sidebar to select the AI Provider (Gemini, OpenRouter, Groq, or Together.AI) that will be used for all LLM tasks (itinerary suggestions, quotation structuring).
+- The currently active provider and model (for OpenRouter, Groq, Together.AI) are displayed.
 
 ---
 
@@ -244,6 +247,8 @@ The application requires the following environment variables to be set in the `.
 - `OPENROUTER_DEFAULT_MODEL`: (Optional) The default model to use with OpenRouter (e.g., `google/gemini-flash-1.5`, `openai/gpt-3.5-turbo`). Defaults to `google/gemini-flash-1.5` if not set.
 - `OPENROUTER_HTTP_REFERER`: (Optional) Your site URL or app name, sent as `HTTP-Referer` to OpenRouter. Defaults to `http://localhost:3000`.
 - `OPENROUTER_APP_TITLE`: (Optional) Your app's title, sent as `X-Title` to OpenRouter. Defaults to `AI Travel Quotation`.
+- `TOGETHERAI_API_KEY`: Your API key for Together.AI.
+- `TOGETHERAI_DEFAULT_MODEL`: (Optional) Default model to use with Together.AI. Supported models include `meta-llama/Llama-3.3-70B-Instruct-Turbo-Free` (default) and `deepseek-ai/DeepSeek-R1-Distill-Llama-70B-free`.
 
 ---
 

--- a/src/llm/llm_providers.py
+++ b/src/llm/llm_providers.py
@@ -92,5 +92,25 @@ def get_llm_instance(provider: str):
             model_name=model_name,
             **llm_params # Spread temperature, max_tokens
         )
+
+    elif provider == "TogetherAI":
+        api_key = os.getenv("TOGETHERAI_API_KEY")
+        model_name = selected_model
+        if not model_name:
+            model_name = os.getenv("TOGETHERAI_DEFAULT_MODEL", "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free")
+        if not api_key:
+            raise ValueError("TOGETHERAI_API_KEY not found for TogetherAI. Check .env file.")
+
+        # ChatOpenAI (used by TogetherAI) typically uses 'max_tokens'
+        if max_tokens_from_state is not None:
+            llm_params['max_tokens'] = max_tokens_from_state
+        
+        print(f"LLM_PROVIDERS.PY: Initializing TogetherAI with model: {model_name}, Params: {llm_params}")
+        return ChatOpenAI(
+            model=model_name,
+            openai_api_key=api_key,
+            base_url="https://api.together.xyz/v1",
+            **llm_params # Spread temperature, max_tokens
+        )
     else:
-        raise ValueError(f"Unsupported AI provider: {provider}. Supported: 'Gemini', 'OpenRouter', 'Groq'.")
+        raise ValueError(f"Unsupported AI provider: {provider}. Supported: 'Gemini', 'OpenRouter', 'Groq', 'TogetherAI'.")

--- a/src/ui/sidebar.py
+++ b/src/ui/sidebar.py
@@ -22,6 +22,11 @@ PROVIDER_MODEL_OPTIONS = {
         "gemini-1.5-flash-latest",
         "gemini-1.5-pro-latest",
         "gemini-1.0-pro"
+    ],
+    "TogetherAI": [
+        "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free",
+        "deepseek-ai/DeepSeek-R1-Distill-Llama-70B-free"
+        # Add other TogetherAI models here if needed
     ]
 }
 
@@ -31,7 +36,7 @@ def render_sidebar():
     Manages AI provider, model, and advanced settings in st.session_state.app_state.ai_config.
     """
     st.sidebar.subheader("⚙️ AI Configuration")
-    ai_provider_options = ["Gemini", "OpenRouter", "Groq"]
+    ai_provider_options = ["Gemini", "OpenRouter", "Groq", "TogetherAI"] # Added TogetherAI
     ai_conf = st.session_state.app_state.ai_config # Shorthand for session state config
 
     # --- Provider Selection ---
@@ -75,6 +80,7 @@ def render_sidebar():
         if active_provider == "OpenRouter": default_model_env_var = os.getenv("OPENROUTER_DEFAULT_MODEL")
         elif active_provider == "Groq": default_model_env_var = os.getenv("GROQ_DEFAULT_MODEL")
         elif active_provider == "Gemini": default_model_env_var = os.getenv("GOOGLE_DEFAULT_MODEL")
+        elif active_provider == "TogetherAI": default_model_env_var = os.getenv("TOGETHERAI_DEFAULT_MODEL")
 
         current_model_index = 0
         if ai_conf.selected_model_for_provider and ai_conf.selected_model_for_provider in available_models:

--- a/tests/llm/test_llm_providers.py
+++ b/tests/llm/test_llm_providers.py
@@ -1,0 +1,94 @@
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Assuming ChatOpenAI is imported in the module we are testing like:
+# from langchain_openai import ChatOpenAI
+# If it's imported as `from langchain_openai.chat_models import ChatOpenAI`, the patch path needs to reflect that.
+# For now, we'll assume `src.llm.llm_providers.ChatOpenAI` is the correct path to mock.
+
+from src.llm.llm_providers import get_llm_instance
+from src.models import AIConfigState, AppSessionState # Use AppSessionState
+
+# Mock Streamlit's session state
+# No longer needed as we will mock st.session_state directly in tests or via mock_st argument.
+
+@patch('src.llm.llm_providers.st') # Mocking streamlit (st) module used in llm_providers
+class TestTogetherAIProvider(unittest.TestCase):
+
+    def setUp(self):
+        # Basic AIConfigState, specific tests will override parts of this
+        self.mock_ai_config = AIConfigState(
+            # provider="TogetherAI", # Provider is passed to get_llm_instance directly
+            selected_model_for_provider=None,
+            temperature=0.5,
+            max_tokens=150
+        )
+        # This will be assigned to mock_st.session_state.app_state in each test
+        self.mock_app_session_state = AppSessionState(ai_config=self.mock_ai_config)
+
+    @patch.dict(os.environ, {"TOGETHERAI_API_KEY": "test_together_key"})
+    @patch('src.llm.llm_providers.ChatOpenAI') # Mocking ChatOpenAI where it's used
+    def test_get_llm_instance_togetherai_default_model(self, mock_chat_openai_class, mock_st):
+        """Test TogetherAI initialization with default model."""
+        mock_st.session_state.app_state = self.mock_app_session_state
+        
+        llm_instance = get_llm_instance(provider="TogetherAI")
+
+        mock_chat_openai_class.assert_called_once()
+        args, kwargs = mock_chat_openai_class.call_args
+        self.assertEqual(kwargs['model'], "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free") # Default model
+        self.assertEqual(kwargs['openai_api_key'], "test_together_key")
+        self.assertEqual(kwargs['base_url'], "https://api.together.xyz/v1")
+        self.assertEqual(kwargs['temperature'], 0.5)
+        self.assertEqual(kwargs['max_tokens'], 150)
+        self.assertIsNotNone(llm_instance)
+
+    @patch.dict(os.environ, {"TOGETHERAI_API_KEY": "test_together_key"})
+    @patch('src.llm.llm_providers.ChatOpenAI')
+    def test_get_llm_instance_togetherai_selected_model(self, mock_chat_openai_class, mock_st):
+        """Test TogetherAI initialization with a user-selected model."""
+        self.mock_ai_config.selected_model_for_provider = "deepseek-ai/DeepSeek-R1-Distill-Llama-70B-free"
+        # Re-create AppSessionState with updated ai_config
+        mock_st.session_state.app_state = AppSessionState(ai_config=self.mock_ai_config)
+
+        llm_instance = get_llm_instance(provider="TogetherAI")
+
+        mock_chat_openai_class.assert_called_once()
+        args, kwargs = mock_chat_openai_class.call_args
+        self.assertEqual(kwargs['model'], "deepseek-ai/DeepSeek-R1-Distill-Llama-70B-free")
+        self.assertEqual(kwargs['openai_api_key'], "test_together_key")
+        self.assertEqual(kwargs['base_url'], "https://api.together.xyz/v1")
+        self.assertEqual(kwargs['temperature'], 0.5)
+        self.assertEqual(kwargs['max_tokens'], 150)
+        self.assertIsNotNone(llm_instance)
+
+    @patch.dict(os.environ, {"TOGETHERAI_API_KEY": "test_together_key", "TOGETHERAI_DEFAULT_MODEL": "env_default_model"})
+    @patch('src.llm.llm_providers.ChatOpenAI')
+    def test_get_llm_instance_togetherai_env_default_model(self, mock_chat_openai_class, mock_st):
+        """Test TogetherAI initialization with default model from environment variable."""
+        # Ensure no specific model is selected in session state
+        self.mock_ai_config.selected_model_for_provider = None
+        # Re-create AppSessionState with updated ai_config
+        mock_st.session_state.app_state = AppSessionState(ai_config=self.mock_ai_config)
+        
+        llm_instance = get_llm_instance(provider="TogetherAI")
+
+        mock_chat_openai_class.assert_called_once()
+        args, kwargs = mock_chat_openai_class.call_args
+        self.assertEqual(kwargs['model'], "env_default_model") 
+        self.assertEqual(kwargs['openai_api_key'], "test_together_key")
+        self.assertEqual(kwargs['base_url'], "https://api.together.xyz/v1")
+        self.assertIsNotNone(llm_instance)
+
+    @patch.dict(os.environ, {}, clear=True) # Ensure TOGETHERAI_API_KEY is not set
+    def test_get_llm_instance_togetherai_missing_key(self, mock_st):
+        """Test TogetherAI initialization raises ValueError if API key is missing."""
+        mock_st.session_state.app_state = self.mock_app_session_state
+        
+        with self.assertRaises(ValueError) as context:
+            get_llm_instance(provider="TogetherAI")
+        self.assertIn("TOGETHERAI_API_KEY not found", str(context.exception))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Makes Together.AI and its supported free models selectable in the Streamlit UI sidebar.

Key changes in `src/ui/sidebar.py`:
- Added "TogetherAI" to the list of LLM providers in the provider selection dropdown.
- Updated the `PROVIDER_MODEL_OPTIONS` dictionary to include: "TogetherAI": [ "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free", "deepseek-ai/DeepSeek-R1-Distill-Llama-70B-free" ] This populates the model selection dropdown when TogetherAI is chosen.
- Ensured that the `TOGETHERAI_DEFAULT_MODEL` environment variable is checked for setting the default selected model for Together.AI.

No changes were needed in `src/models.py` as the model lists are managed within `src/ui/sidebar.py`, consistent with other providers.